### PR TITLE
Remove SonarQube dependencies from annotation jar

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -8,21 +8,4 @@
   <artifactId>qualinsight-plugins-sonarqube-wtf-api</artifactId>
   <description>QualInsight "What the fuck!" annotation api.</description>
   <packaging>jar</packaging>
-  <dependencies>
-    <dependency>
-      <groupId>org.codehaus.sonar</groupId>
-      <artifactId>sonar-plugin-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.sonar.sslr-squid-bridge</groupId>
-      <artifactId>sslr-squid-bridge</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.java</groupId>
-      <artifactId>sonar-java-plugin</artifactId>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
 </project>


### PR DESCRIPTION
Hi,

I would like to suggest removing the dependency on the SonarQube API from the annotation jar. I believe the dependency is in fact not needed.
We have just started using the WTF plugin in an larger development project, and the enormous amount of JARs being pulled into the classpath by the WTF API jar is prohibitive.

I hope that's ok with you.
Thank you for this really nice plugin - good idea!

All the best
 --Thomas